### PR TITLE
confim my github identity

### DIFF
--- a/projects-tests/devpi/users.json
+++ b/projects-tests/devpi/users.json
@@ -200,7 +200,7 @@
   "vlcinsky": true,
   "vmalloc": true,
   "vortec": null,
-  "wcooley": null,
+  "wcooley": true,
   "witsch": true,
   "zealot0630": null,
   "zirpu": true,


### PR DESCRIPTION
Per https://bitbucket.org/hpk42/devpi/issues/389/move-to-github-need-user-names#comment-34684256

GH seems to have added the newline at the end; I used the "quick edit" feature.